### PR TITLE
fix: get rid of lodash.isEqual and replace with a simple deep comparison function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const isEqual = require('lodash.isequal')
-
+// const isEqual = require('lodash.isequal')
+const isEqual = require('./isEqual')
 let testsStarted = 0
 
 function test (testName, testFunction) {

--- a/isEqual.js
+++ b/isEqual.js
@@ -1,0 +1,19 @@
+
+function isEqual (a, b) {
+  if (a === b) return true
+
+  if (a == null || typeof a !== 'object' ||
+        b == null || typeof b !== 'object') return false
+
+  const keysA = Object.keys(a); const keysB = Object.keys(b)
+
+  if (keysA.length != keysB.length) return false
+
+  for (const key of keysA) {
+    if (!keysB.includes(key) || !isEqual(a[key], b[key])) return false
+  }
+
+  return true
+}
+
+module.exports = isEqual

--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     "url": "https://github.com/kdoran/smalltest/issues"
   },
   "homepage": "https://github.com/kdoran/smalltest#readme",
-  "dependencies": {
-    "lodash.isequal": "^4.5.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "rollup": "^1.1.2",
     "rollup-plugin-commonjs": "^9.2.0",


### PR DESCRIPTION
I think using the entire lodash.isEqual library was too overkill Just added this to make it lightweight.
